### PR TITLE
Relax r10k version requirement

### DIFF
--- a/puppetfile_fixtures_generator.gemspec
+++ b/puppetfile_fixtures_generator.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.1'
 
   s.add_runtime_dependency 'highline', '~> 1.7'
-  s.add_runtime_dependency 'r10k', '~> 2.3.0'
+  s.add_runtime_dependency 'r10k', '~> 2.3'
   s.add_runtime_dependency 'trollop', '~> 2.1'
 
   s.add_development_dependency 'bundler', '~> 1.10'


### PR DESCRIPTION
Allow r10k versions >= 2.3.0, but < 3.0.0.